### PR TITLE
#6 Limit the template to Drupal 10.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         }
     ],
     "require": {
+        "drupal/core": "^10",
         "koodimonni/composer-dropin-installer": "*"
     }
 }


### PR DESCRIPTION
This PR adds Drupal 10 requirement to composer.json as the template is Drupal 10 oriented. We can later add separate branches / versions for other Drupals.