### PR TITLE
#8 Make recipe parameter "required".

### DIFF
--- a/.lando.base.yml
+++ b/.lando.base.yml
@@ -1,5 +1,4 @@
 name: drupal-project
-recipe: drupal10
 
 config:
   php: "8.1"

--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ minimally the *name* parameter.
    If you are creating new project, then you need to create .lando.yml file with the following:
    ```
    name: your-project-name
-
-   # Optional to make sure upstream does not change this eg to drupal11 at some point.
    recipe: drupal10
    ```
 


### PR DESCRIPTION
At some point we wanted to keep the minimal .lando.yml in projects to 1 line - **name: some-project**

But if you remove recipe and you don't have this package yet installed, then you're missing composer command thus you can't install this package with `composer install`

Let's remove the part in readme that keeping recipe in your local .lando.yml is optional.