### PR TITLE
#12 Move DRUSH_OPTIONS_URI to .env file.

### DIFF
--- a/.lando.base.yml
+++ b/.lando.base.yml
@@ -62,7 +62,6 @@ services:
         DB_USER_DRUPAL: drupal10
         DB_PASS_DRUPAL: drupal10
         DB_HOST_DRUPAL: database
-        DRUSH_OPTIONS_URI: https://drupal-project.lndo.site
         VARNISH_ADMIN_HOST: varnish
         # Support debugging with XDEBUG 3.
         XDEBUG_MODE:

--- a/.lando/core/.env
+++ b/.lando/core/.env
@@ -1,2 +1,3 @@
 # Inject additional environment variables into every Lando service
 # @see: https://docs.lando.dev/config/env.html#environment-files
+DRUSH_OPTIONS_URI=https://drupal-project.lndo.site


### PR DESCRIPTION
Move DRUSH_OPTIONS_URI to .env file so it's easy to overwrite it in local .env file.