### PR TITLE
#14 Fix adminer service type.

### DIFF
--- a/.lando.base.yml
+++ b/.lando.base.yml
@@ -44,7 +44,7 @@ tooling:
 
 services:
   adminer:
-    type: lando
+    type: compose
     services:
       image: dehy/adminer
       command: /bin/s6-svscan /etc/services.d


### PR DESCRIPTION
Type: lando does not work yet on current development environment. Let's use the old composer way.