### PR TITLE
#14 Fix services-adminer-run-as-root.sh not running.

### DIFF
--- a/.lando/core/_run-scripts.sh
+++ b/.lando/core/_run-scripts.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
 #
-# Helper script to run other scripts and allow overriding them by having same file in .lando/custom folder.
+# Helper script to run other scripts and allow overriding them by having the same file in .lando/custom folder.
 #
 
 set -exu
@@ -10,17 +10,17 @@ export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/app/vendor/bin
 script_name="$1"
 
 # Check if a custom script exists in .lando/custom
-custom_script=".lando/custom/$script_name"
-core_script=".lando/core/$script_name"
+custom_script="/app/.lando/custom/$script_name"
+core_script="/app/.lando/core/$script_name"
 
 # Check if the custom script exists, and if so, run it.
 if [ -f "$custom_script" ]; then
     echo "Running custom script: $custom_script"
-    bash "$custom_script"
+    sh "$custom_script"
 elif [ -f "$core_script" ]; then
-    # If custom script doesn't exist, run the core script.
+    # If the custom script doesn't exist, run the core script.
     echo "Running core script: $core_script"
-    bash "$core_script"
+    sh "$core_script"
 else
     echo "Script not found: $script_name"
     exit 1


### PR DESCRIPTION
Fix services-adminer-run-as-root.sh not running. Our _run-scripts.sh was using bash, but Adminer service does not have bash. Let's change to using sh as it seems to be available also in appserver and maybe it's more commonly used.