### PR TITLE
#18 Load also custom .env file from .lando/custom/.env.

### DIFF
--- a/.lando.base.yml
+++ b/.lando.base.yml
@@ -153,6 +153,7 @@ events:
 
 env_file:
   - .lando/core/.env
+  - .lando/custom/.env
 
 # Tested with Lando version
 version: v3.18.0


### PR DESCRIPTION
Originally your .env file could have been located at .lando/.env but now in this project we move it to .lando/custom/.env . Base file could have both core and custom entries so we would not have to define it in .lando.yml

```
env_file:
  - .lando/core/.env
```

->

```
env_file:
  - .lando/core/.env
  - .lando/custom/.env
```