### PR TITLE
Feature/20 add extensions, change install steps

### DIFF
--- a/.lando.base.yml
+++ b/.lando.base.yml
@@ -143,6 +143,8 @@ proxy:
 events:
   post-db-import:
     - appserver: "cd $LANDO_WEBROOT && drush cache:rebuild -y && drush @local user:login"
+  pre-rebuild:
+    - appserver: /app/vendor/wunderio/lando-drupal/scripts/load_extensions.sh
 
 env_file:
   - .lando/core/.env

--- a/.lando.base.yml
+++ b/.lando.base.yml
@@ -20,9 +20,6 @@ tooling:
     description: "Runs grumphp commands"
     cmd:
       - appserver: ./vendor/bin/grumphp
-  npm:
-    description: "Runs npm commands"
-    service: node
   phpunit:
     description: "Runs PHPUnit commands"
     user: www-data
@@ -119,10 +116,6 @@ services:
     type: mailhog
     hogfrom:
       - appserver
-  node:
-    type: "node:16"
-    build:
-      - "npm install"
   # varnish:
   #   type: "varnish:6"
   #   backends:

--- a/.lando.base.yml
+++ b/.lando.base.yml
@@ -38,6 +38,10 @@ tooling:
     cmd:
       - appserver: "/app/.lando/core/_run-scripts.sh tooling-xdebug.sh"
     user: root
+  load-wunderio-lando-drupal-extensions:
+    description: "After adding new extensions under wunderio:extensions: in your .lando.yml this is needed to ensure new .lando.base.yml is built. Otherwise you'd need to run rebuild 2 times."
+    cmd:
+      - appserver: "/app/vendor/wunderio/lando-drupal/scripts/load_extensions.sh"
 
 services:
   adminer:
@@ -144,7 +148,7 @@ events:
   post-db-import:
     - appserver: "cd $LANDO_WEBROOT && drush cache:rebuild -y && drush @local user:login"
   pre-rebuild:
-    - appserver: /app/vendor/wunderio/lando-drupal/scripts/load_extensions.sh
+    - appserver: "/app/vendor/wunderio/lando-drupal/scripts/load_extensions.sh"
 
 env_file:
   - .lando/core/.env

--- a/README.md
+++ b/README.md
@@ -38,9 +38,13 @@ minimally the *name* parameter.
    .lando.base.yml. If you have any custom code in .lando/ then move these to
    .lando/custom/ folder and change the references in .lando.yml
 
-6. Optionally enable disabled services in .lando.base.yml by copying these over to .lando.yml and
-   uncomment them.
+6. Optionally enable custom extensions eg node and then rebuild Lando:
+   ```
+   lando load-wunderio-lando-drupal-extensions node
+   lando rebuild
+   ```
 
+   All available extensions are listed at https://github.com/wunderio/lando-drupal/tree/main/extensions
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ minimally the *name* parameter.
 
 - **composer:** Runs Composer commands.
 - **grumphp:** Runs GrumPHP commands.
-- **npm:** Runs npm commands.
 - **phpunit:** Runs PHPUnit commands with custom options.
 - **regenerate-phpunit-config:** Regenerates fresh PHPUnit configuration.
 - **varnishadm:** Runs varnishadm commands.
@@ -99,7 +98,6 @@ Currently, there are 3 scripts:
 - **adminer:** [Adminer database management tool](https://github.com/dehy/docker-adminer).
 - **chrome:** Configuration for running Chrome WebDriver.
 - **mailhog:** Configuration for MailHog, a mail testing tool.
-- **node:** Configuration for Node.js 16, with npm installation.
 - **proxy:** Configuration for proxy settings.
 
 Service commands that are defined as scripts (.lando/core/services-*.sh files) can be overwritten
@@ -125,8 +123,8 @@ Currently, there are 2 script:
 
 - This Lando configuration is designed for a Drupal 10 project.
 - It includes custom PHP and database configuration files.
-- Tooling commands are provided for Composer, GrumPHP, npm, PHPUnit, Varnishadm, and Xdebug.
-- Services are configured for the primary application server, Chrome WebDriver, MailHog, and Node.js.
+- Tooling commands are provided for Composer, GrumPHP, PHPUnit, Varnishadm, and Xdebug.
+- Services are configured for the primary application server, Chrome WebDriver and MailHog.
 - Custom events are defined to perform actions after a database import.
 - The configuration is tested with Lando version 3.18.0.
 - Please make sure to adjust any paths or configurations as needed for your specific project and environment.

--- a/README.md
+++ b/README.md
@@ -6,40 +6,27 @@ minimally the *name* parameter.
 
 ## Installation
 
-1. Add this to your `composer.json`:
-   ```json
-   {
-       "extra": {
-           "dropin-paths": {
-               "/": [
-                   "package:wunderio/lando-drupal"
-               ]
-           }
-       }
-   }
-   ```
-
-2. Then install the composer package as usual with:
+1. Install the composer package:
 
    ```
    composer require wunderio/lando-drupal --dev
    ```
 
-3. Add these into the main project's `.gitignore`:
+2. Add these into the main project's `.gitignore`:
    ```
    # wunderio/lando-drupal
    .lando.base.yml
    .lando/core/
    ```
-4. Move your current .lando/* files to .lando/custom/
+3. Move your current .lando/* files to .lando/custom/
 
-5. Add changes to GIT:
+4. Add changes to GIT:
    ```
    git add .lando/custom/ &&
    git add -p .gitignore composer.json composer.lock
    ```
 
-6. Depending on your project either create or update your .lando.yml.
+5. Depending on your project either create or update your .lando.yml.
 
    If you are creating new project, then you need to create .lando.yml file with the following:
    ```
@@ -51,7 +38,7 @@ minimally the *name* parameter.
    .lando.base.yml. If you have any custom code in .lando/ then move these to
    .lando/custom/ folder and change the references in .lando.yml
 
-7. Optionally enable disabled services in .lando.base.yml by copying these over to .lando.yml and
+6. Optionally enable disabled services in .lando.base.yml by copying these over to .lando.yml and
    uncomment them.
 
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "wunderio/lando-drupal",
     "description": "Wunder's extendable template for Lando Drupal projects.",
-    "type": "project",
+    "type": "composer-plugin",
     "license": "GPL-2.0-or-later",
     "homepage": "https://github.com/wunderio/lando-drupal",
     "authors": [
@@ -14,6 +14,17 @@
     ],
     "require": {
         "drupal/core": "^10",
-        "koodimonni/composer-dropin-installer": "*"
+        "composer-plugin-api": "^2.0"
+    },
+    "require-dev": {
+        "composer/composer": "^2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Wunderio\\LandoDrupal\\Composer\\": "src/"
+        }
+    },
+    "extra": {
+        "class": "Wunderio\\LandoDrupal\\Composer\\InstallHelperPlugin"
     }
 }

--- a/extensions/node/.lando.yml
+++ b/extensions/node/.lando.yml
@@ -1,0 +1,10 @@
+tooling:
+  npm:
+    description: "Runs npm commands"
+    service: node
+
+services:
+  node:
+    type: "node:16"
+    build:
+      - "npm install"

--- a/extensions/node/README.md
+++ b/extensions/node/README.md
@@ -4,7 +4,13 @@ This extension adds Node.js 16 and npm to the Lando configuration.
 
 ## Installation
 
-1. Add to your local .lando.yml file:
+1. Add node extension to your .lando.yml file:
+
+   ```
+   lando load-wunderio-lando-drupal-extensions node
+   ```
+
+   This will write the following to your .lando.yml file:
 
    ```
    wunderio:
@@ -12,14 +18,20 @@ This extension adds Node.js 16 and npm to the Lando configuration.
        - node
    ```
 
+   You might want to adjust the position of the new entry in .lando.yml file. For example, if you have
+   **version** parameters last, then you might want to move the wunderio entry before that. It's just
+   a matter of preference.
+
 2. Rebuild Lando:
 
    ```
-   # Need to run once after updating the extensions so you would not need to rebuild 2 times.
-   # This will merge the extension configuration into .lando.base.yml.
-   lando load-wunderio-lando-drupal-extensions
-   # Rebuild Lando.
    lando rebuild
+   ```
+
+3. Add the changes to GIT.
+
+   ```
+   git add .lando.base.yml .lando.yml
    ```
 
 ## Overview

--- a/extensions/node/README.md
+++ b/extensions/node/README.md
@@ -15,6 +15,10 @@ This extension adds Node.js 16 and npm to the Lando configuration.
 2. Rebuild Lando:
 
    ```
+   # Need to run once after updating the extensions so you would not need to rebuild 2 times.
+   # This will merge the extension configuration into .lando.base.yml.
+   lando load-wunderio-lando-drupal-extensions
+   # Rebuild Lando.
    lando rebuild
    ```
 

--- a/extensions/node/README.md
+++ b/extensions/node/README.md
@@ -1,0 +1,31 @@
+# Node extension
+
+This extension adds Node.js 16 and npm to the Lando configuration.
+
+## Installation
+
+1. Add to your local .lando.yml file:
+
+   ```
+   wunderio:
+     extensions:
+       - node
+   ```
+
+2. Rebuild Lando:
+
+   ```
+   lando rebuild
+   ```
+
+## Overview
+
+**Configuration Overview:**
+
+**Tooling Commands:**
+
+- **npm:** Runs npm commands.
+
+**Services:**
+
+- **node:** Configuration for Node.js 16, with npm installation.

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,7 +4,10 @@
 # This file contains common functions used by other scripts.
 #
 
-# Help to print messages to the user.
+# Helper to print log messages to the user.
+#
+# Parameters:
+#   $1: message - The message to be logged.
 log_message() {
   echo "wunderio/lando-drupal: $1"
 }

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -10,51 +10,51 @@ log_message() {
 }
 
 # Install yq tool to be able to merge YAML files.
-# Installation is done in ~/bin directory as we don't have root access.
-install_yq_inside_lando() {
+#
+# In Lando installation is done in ~/bin directory as we don't have root access.
+# So in Lando, we use the freshly installed ~/bin/yq, otherwise in host,
+# we use the Docker container.
+setup_yq() {
   # Define the desired version of yq.
   YQ_VERSION="4.35.2"
 
-  # Check if the `yq` binary already exists.
-  if [ -f ~/bin/yq ]; then
-    return
-  fi
-
-  # Define the architecture-specific URL.
-  YQ_URL="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
-
-  # Check if the ~/bin directory exists, and if not, create it.
-  [ -d ~/bin ] || mkdir -p ~/bin
-
-  # Download yq binary.
-  wget -q "$YQ_URL" -O ~/bin/yq
-  chmod +x ~/bin/yq
-
-  # Add ~/bin to PATH if not already there.
-  if [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
-    echo 'export PATH="$HOME/bin:$PATH"' >> ~/.bashrc
-    # Add it to the current shell session as well.
-    export PATH="$HOME/bin:$PATH"
-  fi
-
-  # Inform the user that installation is complete.
-  log_message "yq has been installed."
-}
-
-# Make sure yq is available and assign it to yq wrapper we can use in this script.
-# If we are inside Lando, we use the freshly installed ~/bin/yq, otherwise in host,
-# we use the Docker container.
-install_yq() {
   if [ -n "$LANDO" ]; then
-    install_yq_inside_lando
+    # Check if the `yq` binary already exists.
+    if [ -f ~/bin/yq ]; then
+      yq() {
+        ~/bin/yq "$@"
+      }
+
+      return
+    fi
+
+    # Define the architecture-specific URL.
+    YQ_URL="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+
+    # Check if the ~/bin directory exists, and if not, create it.
+    [ -d ~/bin ] || mkdir -p ~/bin
+
+    # Download yq binary.
+    wget -q "$YQ_URL" -O ~/bin/yq
+    chmod +x ~/bin/yq
+
+    # Add ~/bin to PATH if not already there.
+    if [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
+      echo 'export PATH="$HOME/bin:$PATH"' >> ~/.bashrc
+      # Add it to the current shell session as well.
+      export PATH="$HOME/bin:$PATH"
+    fi
 
     yq() {
       ~/bin/yq "$@"
     }
+
+    # Inform the user that installation is complete.
+    log_message "yq has been installed."
   else
     # Function to run yq using the Docker container in the host.
     yq() {
-      docker run --rm -v "$(pwd)":/workdir mikefarah/yq "$@"
+      docker run --rm -v "$(pwd)":/workdir mikefarah/yq:$YQ_VERSION "$@"
     }
   fi
 }

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -1,0 +1,60 @@
+#
+# _common.sh
+#
+# This file contains common functions used by other scripts.
+#
+
+# Help to print messages to the user.
+log_message() {
+  echo "wunderio/lando-drupal: $1"
+}
+
+# Install yq tool to be able to merge YAML files.
+# Installation is done in ~/bin directory as we don't have root access.
+install_yq_inside_lando() {
+  # Define the desired version of yq.
+  YQ_VERSION="4.35.2"
+
+  # Check if the `yq` binary already exists.
+  if [ -f ~/bin/yq ]; then
+    return
+  fi
+
+  # Define the architecture-specific URL.
+  YQ_URL="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+
+  # Check if the ~/bin directory exists, and if not, create it.
+  [ -d ~/bin ] || mkdir -p ~/bin
+
+  # Download yq binary.
+  wget -q "$YQ_URL" -O ~/bin/yq
+  chmod +x ~/bin/yq
+
+  # Add ~/bin to PATH if not already there.
+  if [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
+    echo 'export PATH="$HOME/bin:$PATH"' >> ~/.bashrc
+    # Add it to the current shell session as well.
+    export PATH="$HOME/bin:$PATH"
+  fi
+
+  # Inform the user that installation is complete.
+  log_message "yq has been installed."
+}
+
+# Make sure yq is available and assign it to yq wrapper we can use in this script.
+# If we are inside Lando, we use the freshly installed ~/bin/yq, otherwise in host,
+# we use the Docker container.
+install_yq() {
+  if [ -n "$LANDO" ]; then
+    install_yq_inside_lando
+
+    yq() {
+      ~/bin/yq "$@"
+    }
+  else
+    # Function to run yq using the Docker container in the host.
+    yq() {
+      docker run --rm -v "$(pwd)":/workdir mikefarah/yq "$@"
+    }
+  fi
+}

--- a/scripts/load_extensions.sh
+++ b/scripts/load_extensions.sh
@@ -13,10 +13,11 @@ log_message() {
   echo "wunderio/lando-drupal: $1"
 }
 
-# Check if yq is installed
+# Install yq tool to be able to merge yaml files.
+# Installation is done in ~/bin directory as we don't have root access.
 install_yq() {
-  # Define the desired version of yq
-  YQ_VERSION="4.13.3"
+  # Define the desired version of yq.
+  YQ_VERSION="4.35.2"
 
   # Check if the `yq` binary already exists.
   if [ -f ~/bin/yq ]; then
@@ -29,7 +30,7 @@ install_yq() {
   # Check if the ~/bin directory exists, and if not, create it.
   [ -d ~/bin ] || mkdir -p ~/bin
 
-  # Download yq binary
+  # Download yq binary.
   wget -q "$YQ_URL" -O ~/bin/yq
   chmod +x ~/bin/yq
 
@@ -54,7 +55,7 @@ if [ -n "$LANDO" ]; then
     ~/bin/yq "$@"
   }
 else
-  # Function to run yq using the docker container.
+  # Function to run yq using the docker container in host.
   yq() {
     docker run --rm -v "$(pwd)":/workdir mikefarah/yq "$@"
   }

--- a/scripts/load_extensions.sh
+++ b/scripts/load_extensions.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Use yq to extract the extensions section
+cd ..
+
+echo $(pwd)
+
+extensions=$(docker run --rm -v "$(pwd)":/workdir mikefarah/yq eval '.wunderio.extensions[]' .lando.yml)
+
+# Iterate over the extensions
+for extension in $extensions; do
+    echo "Extension: $extension"
+    # Add your processing logic here
+done

--- a/scripts/load_extensions.sh
+++ b/scripts/load_extensions.sh
@@ -1,14 +1,66 @@
 #!/bin/bash
 
-# Use yq to extract the extensions section
-cd ..
+#
+# Helper script to load custom extensions from .lando.yml
+#
+# This is not native Lando feature. It is a workaround to load extensions because we
+# only have one .lando.base.yml and we want to be able to keep it minimal and then
+# add extensions on top of it eg node, elasticsearch etc.
+#
 
-echo $(pwd)
+# Check if yq is installed
+install_yq() {
+  # Define the desired version of yq
+  YQ_VERSION="4.13.3"
 
-extensions=$(docker run --rm -v "$(pwd)":/workdir mikefarah/yq eval '.wunderio.extensions[]' .lando.yml)
+  # Check if the `yq` binary already exists
+  if [ -f ~/bin/yq ]; then
+    echo "yq is already installed."
+    return
+  fi
 
-# Iterate over the extensions
-for extension in $extensions; do
-    echo "Extension: $extension"
-    # Add your processing logic here
+  # Define the architecture-specific URL
+  YQ_URL="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+
+  # Check if the ~/bin directory exists, and if not, create it
+  [ -d ~/bin ] || mkdir -p ~/bin
+
+  # Download yq binary
+  wget -q "$YQ_URL" -O ~/bin/yq
+  chmod +x ~/bin/yq
+
+  # Add ~/bin to PATH if not already there
+  if [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
+    echo 'export PATH="$HOME/bin:$PATH"' >> ~/.bashrc
+    # Add it to the current shell session as well
+    export PATH="$HOME/bin:$PATH"
+  fi
+
+  # Inform the user that installation is complete
+  echo "yq has been installed."
+}
+
+# Make sure yq is available and assign it to yq wrapper we can use in this script.
+# If we are inside Lando, we use the freshly installed ~/bin/yq, otherwise in host
+# we use the docker container
+if [ -n "$LANDO" ]; then
+  install_yq
+
+  yq() {
+    ~/bin/yq "$@"
+  }
+else
+  # Function to run yq using the docker container
+  yq() {
+    docker run --rm -v "$(pwd)":/workdir mikefarah/yq "$@"
+  }
+fi
+
+# Use yq to extract the extension values from .lando.yml and store them in an array.
+extensions=($(yq eval '.wunderio.extensions[]' .lando.yml))
+
+# Iterate over the array of extensions
+for extension in "${extensions[@]}"; do
+  echo "Processing extension: $extension"
+  # Add your logic here for each extension
 done

--- a/scripts/load_extensions.sh
+++ b/scripts/load_extensions.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Helper script to load custom extensions from .lando.yml
+# Helper script to load custom extensions from extensions folder.
 #
 # This is not native Lando feature. It is a workaround to load extensions because we
 # only have one .lando.base.yml and we want to be able to keep it minimal and then
@@ -71,7 +71,7 @@ for extension in "${extensions[@]}"; do
   extension_dir="vendor/wunderio/lando-drupal/extensions/$extension"
   extension_path="$extension_dir/.lando.yml"
 
-  # Check if the extension_path exists before merging
+  # Check if the extension_path exists before merging.
   if [ -f "$extension_path" ]; then
     # Use yq to merge the extension-specific .lando.yml into .lando.base.yml
     yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' .lando.base.yml "$extension_path" > .lando.base.tmp.yml

--- a/scripts/load_extensions.sh
+++ b/scripts/load_extensions.sh
@@ -18,36 +18,35 @@ install_yq() {
   # Define the desired version of yq
   YQ_VERSION="4.13.3"
 
-  # Check if the `yq` binary already exists
+  # Check if the `yq` binary already exists.
   if [ -f ~/bin/yq ]; then
-    log_message "yq is already installed."
     return
   fi
 
-  # Define the architecture-specific URL
+  # Define the architecture-specific URL.
   YQ_URL="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
 
-  # Check if the ~/bin directory exists, and if not, create it
+  # Check if the ~/bin directory exists, and if not, create it.
   [ -d ~/bin ] || mkdir -p ~/bin
 
   # Download yq binary
   wget -q "$YQ_URL" -O ~/bin/yq
   chmod +x ~/bin/yq
 
-  # Add ~/bin to PATH if not already there
+  # Add ~/bin to PATH if not already there.
   if [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
     echo 'export PATH="$HOME/bin:$PATH"' >> ~/.bashrc
     # Add it to the current shell session as well
     export PATH="$HOME/bin:$PATH"
   fi
 
-  # Inform the user that installation is complete
+  # Inform the user that installation is complete.
   log_message "yq has been installed."
 }
 
 # Make sure yq is available and assign it to yq wrapper we can use in this script.
 # If we are inside Lando, we use the freshly installed ~/bin/yq, otherwise in host
-# we use the docker container
+# we use the docker container.
 if [ -n "$LANDO" ]; then
   install_yq
 
@@ -55,7 +54,7 @@ if [ -n "$LANDO" ]; then
     ~/bin/yq "$@"
   }
 else
-  # Function to run yq using the docker container
+  # Function to run yq using the docker container.
   yq() {
     docker run --rm -v "$(pwd)":/workdir mikefarah/yq "$@"
   }
@@ -66,7 +65,7 @@ extensions=($(yq eval '.wunderio.extensions[]' .lando.yml))
 
 # Iterate over the array of extensions and merge them to project.
 for extension in "${extensions[@]}"; do
-  log_message "processing extension: $extension"
+  log_message "Installing extension: $extension"
   # Build the path to the extension-specific .lando.yml file
   extension_dir="vendor/wunderio/lando-drupal/extensions/$extension"
   extension_path="$extension_dir/.lando.yml"
@@ -76,7 +75,7 @@ for extension in "${extensions[@]}"; do
     # Use yq to merge the extension-specific .lando.yml into .lando.base.yml
     yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' .lando.base.yml "$extension_path" > .lando.base.tmp.yml
     mv .lando.base.tmp.yml .lando.base.yml
-    log_message "$extension_dir extension installed."
+    log_message "Successfully installed $extension extension."
   else
     echo "$extension_dir extension does not exist."
   fi

--- a/scripts/load_extensions.sh
+++ b/scripts/load_extensions.sh
@@ -10,10 +10,9 @@
 
 cd /app
 
-# Help to print messages to the user.
-log_message() {
-  echo "wunderio/lando-drupal: $1"
-}
+source vendor/wunderio/lando-drupal/scripts/_common.sh
+
+install_yq
 
 # Helper to write extension to .lando.yml.
 add_extension() {
@@ -41,54 +40,6 @@ add_extension() {
     fi
   done
 }
-
-# Install yq tool to be able to merge YAML files.
-# Installation is done in ~/bin directory as we don't have root access.
-install_yq() {
-  # Define the desired version of yq.
-  YQ_VERSION="4.35.2"
-
-  # Check if the `yq` binary already exists.
-  if [ -f ~/bin/yq ]; then
-    return
-  fi
-
-  # Define the architecture-specific URL.
-  YQ_URL="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
-
-  # Check if the ~/bin directory exists, and if not, create it.
-  [ -d ~/bin ] || mkdir -p ~/bin
-
-  # Download yq binary.
-  wget -q "$YQ_URL" -O ~/bin/yq
-  chmod +x ~/bin/yq
-
-  # Add ~/bin to PATH if not already there.
-  if [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
-    echo 'export PATH="$HOME/bin:$PATH"' >> ~/.bashrc
-    # Add it to the current shell session as well.
-    export PATH="$HOME/bin:$PATH"
-  fi
-
-  # Inform the user that installation is complete.
-  log_message "yq has been installed."
-}
-
-# Make sure yq is available and assign it to yq wrapper we can use in this script.
-# If we are inside Lando, we use the freshly installed ~/bin/yq, otherwise in host,
-# we use the Docker container.
-if [ -n "$LANDO" ]; then
-  install_yq
-
-  yq() {
-    ~/bin/yq "$@"
-  }
-else
-  # Function to run yq using the Docker container in the host.
-  yq() {
-    docker run --rm -v "$(pwd)":/workdir mikefarah/yq "$@"
-  }
-fi
 
 # Update .lando.yml and add the extension if it was passed as an argument.
 if [ -n "$1" ]; then

--- a/scripts/load_extensions.sh
+++ b/scripts/load_extensions.sh
@@ -3,17 +3,46 @@
 #
 # Helper script to load custom extensions from extensions folder.
 #
-# This is not native Lando feature. It is a workaround to load extensions because we
+# This is not a native Lando feature. It is a workaround to load extensions because we
 # only have one .lando.base.yml and we want to be able to keep it minimal and then
-# add extensions on top of it eg node, elasticsearch etc.
+# add extensions on top of it, e.g., node, elasticsearch, etc.
 #
+
+cd /app
 
 # Help to print messages to the user.
 log_message() {
   echo "wunderio/lando-drupal: $1"
 }
 
-# Install yq tool to be able to merge yaml files.
+# Helper to write extension to .lando.yml.
+add_extension() {
+  extensions="$1"  # Extensions are provided as a comma-separated string.
+  IFS=',' read -ra extension_array <<< "$extensions"  # Split the string into an array.
+
+  for extension in "${extension_array[@]}"; do
+    # Build the path to the extension-specific .lando.yml file
+    extension_dir="vendor/wunderio/lando-drupal/extensions/${extension}"
+    extension_path="${extension_dir}/.lando.yml"
+
+    if [ ! -f "$extension_path" ]; then
+      log_message "Won't write to .lando.yml as extension \"${extension}\" does not exist at ${extension_dir}."
+      continue
+    fi
+
+    # Check if the extension is already in the .lando.yml file.
+    extension_in_lando_yml=$(yq eval ".wunderio.extensions[] | select(. == \"${extension}\")" .lando.yml)
+    if [ -n "$extension_in_lando_yml" ]; then
+      log_message "\"${extension}\" extension is already in .lando.yml; skipping."
+    else
+      # If the extension is not found, add it.
+      yq eval ".wunderio.extensions += [\"${extension}\"]" -i .lando.yml
+      log_message "Added \"${extension}\" extension to .lando.yml under wunderio:extensions."
+    fi
+  done
+}
+
+# Install yq tool to be able to merge YAML files.
 # Installation is done in ~/bin directory as we don't have root access.
 install_yq() {
   # Define the desired version of yq.
@@ -37,7 +66,7 @@ install_yq() {
   # Add ~/bin to PATH if not already there.
   if [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
     echo 'export PATH="$HOME/bin:$PATH"' >> ~/.bashrc
-    # Add it to the current shell session as well
+    # Add it to the current shell session as well.
     export PATH="$HOME/bin:$PATH"
   fi
 
@@ -46,8 +75,8 @@ install_yq() {
 }
 
 # Make sure yq is available and assign it to yq wrapper we can use in this script.
-# If we are inside Lando, we use the freshly installed ~/bin/yq, otherwise in host
-# we use the docker container.
+# If we are inside Lando, we use the freshly installed ~/bin/yq, otherwise in host,
+# we use the Docker container.
 if [ -n "$LANDO" ]; then
   install_yq
 
@@ -55,10 +84,17 @@ if [ -n "$LANDO" ]; then
     ~/bin/yq "$@"
   }
 else
-  # Function to run yq using the docker container in host.
+  # Function to run yq using the Docker container in the host.
   yq() {
     docker run --rm -v "$(pwd)":/workdir mikefarah/yq "$@"
   }
+fi
+
+# Update .lando.yml and add the extension if it was passed as an argument.
+if [ -n "$1" ]; then
+  # Add the extension to .lando.yml.
+  extension_name="$1"
+  add_extension "$extension_name"
 fi
 
 # Use yq to extract the extension values from .lando.yml and store them in an array.
@@ -66,7 +102,7 @@ extensions=($(yq eval '.wunderio.extensions[]' .lando.yml))
 
 # Iterate over the array of extensions and merge them to project.
 for extension in "${extensions[@]}"; do
-  log_message "Installing extension: $extension"
+  log_message "Preparing to install extension: $extension"
   # Build the path to the extension-specific .lando.yml file
   extension_dir="vendor/wunderio/lando-drupal/extensions/$extension"
   extension_path="$extension_dir/.lando.yml"
@@ -81,3 +117,9 @@ for extension in "${extensions[@]}"; do
     echo "$extension_dir extension does not exist."
   fi
 done
+
+# Print out help message to user to suggest rebuilding Lando now.
+if [ -n "$1" ]; then
+  echo
+  echo "Run 'lando rebuild' to apply the changes."
+fi

--- a/scripts/load_extensions.sh
+++ b/scripts/load_extensions.sh
@@ -12,7 +12,7 @@ cd /app
 
 source vendor/wunderio/lando-drupal/scripts/_common.sh
 
-install_yq
+setup_yq
 
 # Helper to write extension to .lando.yml.
 add_extension() {

--- a/scripts/load_extensions.sh
+++ b/scripts/load_extensions.sh
@@ -15,7 +15,10 @@ source vendor/wunderio/lando-drupal/scripts/_common.sh
 setup_yq
 
 # Helper to write extension to .lando.yml.
-add_extension() {
+#
+# Parameters:
+#   $1: extensions - A comma-separated string of extension names eg node.
+add_extension_to_lando_yml() {
   extensions="$1"  # Extensions are provided as a comma-separated string.
   IFS=',' read -ra extension_array <<< "$extensions"  # Split the string into an array.
 
@@ -45,7 +48,7 @@ add_extension() {
 if [ -n "$1" ]; then
   # Add the extension to .lando.yml.
   extension_name="$1"
-  add_extension "$extension_name"
+  add_extension_to_lando_yml "$extension_name"
 fi
 
 # Use yq to extract the extension values from .lando.yml and store them in an array.

--- a/scripts/load_extensions.sh
+++ b/scripts/load_extensions.sh
@@ -8,6 +8,11 @@
 # add extensions on top of it eg node, elasticsearch etc.
 #
 
+# Help to print messages to the user.
+log_message() {
+  echo "wunderio/lando-drupal: $1"
+}
+
 # Check if yq is installed
 install_yq() {
   # Define the desired version of yq
@@ -15,7 +20,7 @@ install_yq() {
 
   # Check if the `yq` binary already exists
   if [ -f ~/bin/yq ]; then
-    echo "yq is already installed."
+    log_message "yq is already installed."
     return
   fi
 
@@ -37,7 +42,7 @@ install_yq() {
   fi
 
   # Inform the user that installation is complete
-  echo "yq has been installed."
+  log_message "yq has been installed."
 }
 
 # Make sure yq is available and assign it to yq wrapper we can use in this script.
@@ -59,8 +64,20 @@ fi
 # Use yq to extract the extension values from .lando.yml and store them in an array.
 extensions=($(yq eval '.wunderio.extensions[]' .lando.yml))
 
-# Iterate over the array of extensions
+# Iterate over the array of extensions and merge them to project.
 for extension in "${extensions[@]}"; do
-  echo "Processing extension: $extension"
-  # Add your logic here for each extension
+  log_message "processing extension: $extension"
+  # Build the path to the extension-specific .lando.yml file
+  extension_dir="vendor/wunderio/lando-drupal/extensions/$extension"
+  extension_path="$extension_dir/.lando.yml"
+
+  # Check if the extension_path exists before merging
+  if [ -f "$extension_path" ]; then
+    # Use yq to merge the extension-specific .lando.yml into .lando.base.yml
+    yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' .lando.base.yml "$extension_path" > .lando.base.tmp.yml
+    mv .lando.base.tmp.yml .lando.base.yml
+    log_message "$extension_dir extension installed."
+  else
+    echo "$extension_dir extension does not exist."
+  fi
 done

--- a/src/InstallHelperPlugin.php
+++ b/src/InstallHelperPlugin.php
@@ -103,7 +103,14 @@ class InstallHelperPlugin implements PluginInterface, EventSubscriberInterface {
   public function onWunderIoLandoDrupalPackageInstall(PackageEvent $event) {
     /** @var \Composer\DependencyResolver\Operation\InstallOperation $operation */
     $operation = $event->getOperation();
-    $current_package = $operation->getPackage();
+
+    // Composer operations have access to packages, just through different
+    // methods, which depend on whether the operation is an InstallOperation or
+    // an UpdateOperation
+    $current_package = method_exists($operation, 'getPackage')
+      ? $operation->getPackage()
+      : $operation->getInitialPackage();
+
     $current_package_name = $current_package->getName();
 
     // We only want to continue for this package.

--- a/src/InstallHelperPlugin.php
+++ b/src/InstallHelperPlugin.php
@@ -112,6 +112,8 @@ class InstallHelperPlugin implements PluginInterface, EventSubscriberInterface {
     }
 
     self::deployLandoFiles();
+
+    shell_exec('bash vendor/wunderio/lando-drupal/scripts/load_extensions.sh');
   }
 
   /**

--- a/src/InstallHelperPlugin.php
+++ b/src/InstallHelperPlugin.php
@@ -113,7 +113,8 @@ class InstallHelperPlugin implements PluginInterface, EventSubscriberInterface {
 
     self::deployLandoFiles();
 
-    shell_exec('bash vendor/wunderio/lando-drupal/scripts/load_extensions.sh');
+    $output = shell_exec('bash vendor/wunderio/lando-drupal/scripts/load_extensions.sh');
+    $this->io->write("<info>{$output}</info>");
   }
 
   /**

--- a/src/InstallHelperPlugin.php
+++ b/src/InstallHelperPlugin.php
@@ -155,8 +155,6 @@ class InstallHelperPlugin implements PluginInterface, EventSubscriberInterface {
    *   TRUE if recursive copy was successful, FALSE otherwise.
    */
   private static function rcopy($src, $dest): bool {
-    echo "rcopy: Copying $src to $dest\n";
-
     // If source is not a directory stop processing.
     if (!is_dir($src)) {
       echo "Source is not a directory";

--- a/src/InstallHelperPlugin.php
+++ b/src/InstallHelperPlugin.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Wunderio\LandoDrupal\Composer;
+
+use Composer\Composer;
+use Composer\EventDispatcher\EventSubscriberInterface;
+use Composer\Installer\PackageEvent;
+use Composer\Installer\PackageEvents;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
+
+/**
+ * Class InstallHelperPlugin.
+ *
+ * Help to deploy files to project root and install custom extensions.
+ *
+ * @package Wunderio\LandoDrupal\Composer
+ */
+class InstallHelperPlugin implements PluginInterface, EventSubscriberInterface {
+
+  /**
+   * Name of this package.
+   */
+  private const PACKAGE_NAME = 'wunderio/lando-drupal';
+
+  /**
+   * The Composer service.
+   *
+   * @var \Composer\Composer
+   */
+  protected $composer;
+
+  /**
+   * Composer's I/O service.
+   *
+   * @var \Composer\IO\IOInterface
+   */
+  protected $io;
+
+  /**
+   * Full path to project root where composer.json is located.
+   *
+   * Example: /app.
+   *
+   * @var string
+   */
+  protected $projectDir;
+
+  /**
+   * Full path to the vendor directory.
+   *
+   * Example: /app/vendor.
+   *
+   * @var string
+   */
+  protected $vendorDir;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function activate(Composer $composer, IOInterface $io): void {
+    $this->composer = $composer;
+    $this->io = $io;
+    $this->projectDir = getcwd();
+
+    $vendor_dir = $this->composer->getConfig()->get('vendor-dir');
+    $this->vendorDir = realpath($vendor_dir);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      PackageEvents::POST_PACKAGE_INSTALL => [
+        ['onWunderIoLandoDrupalPackageInstall', 0],
+      ],
+      PackageEvents::POST_PACKAGE_UPDATE => [
+        ['onWunderIoLandoDrupalPackageInstall', 0],
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function deactivate(Composer $composer, IOInterface $io) {
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function uninstall(Composer $composer, IOInterface $io) {
+  }
+
+  /**
+   * Install event callback called from getSubscribedEvents().
+   *
+   * @param \Composer\Installer\PackageEvent $event
+   *   Composer package event sent on install/update/remove.
+   */
+  public function onWunderIoLandoDrupalPackageInstall(PackageEvent $event) {
+    /** @var \Composer\DependencyResolver\Operation\InstallOperation $operation */
+    $operation = $event->getOperation();
+    $current_package = $operation->getPackage();
+    $current_package_name = $current_package->getName();
+
+    // We only want to continue for this package.
+    if ($current_package_name !== self::PACKAGE_NAME) {
+      return NULL;
+    }
+
+    self::deployLandoFiles();
+  }
+
+  /**
+   * Update event callback called from getSubscribedEvents().
+   *
+   * @param \Composer\Installer\PackageEvent $event
+   *   Composer package event sent on install/update/remove.
+   */
+  public function onWunderIoLandoDrupalPackageUpdate(PackageEvent $event) {
+    self::deployLandoFiles();
+  }
+
+  /**
+   * Copy the .lando.base.yml file and the .lando/core directory to the project.
+   */
+  private function deployLandoFiles(): void {
+    // Copy over the .lando/core directory.
+    $src_core = "{$this->vendorDir}/" . self::PACKAGE_NAME . '/.lando/core';
+    $dest_core = "{$this->projectDir}/.lando/core";
+    self::rcopy($src_core, $dest_core);
+
+    // Copy over the .lando.base.yml file.
+    $src_base = "{$this->vendorDir}/" . self::PACKAGE_NAME . '/.lando.base.yml';
+    self::copy($src_base, $this->projectDir);
+  }
+
+  /**
+   * Recursively copy files from one directory to another.
+   *
+   * Code is borrowed from koodimonni/composer-dropin-installer.
+   *
+   * @param string $src
+   *   Source of files being copied.
+   * @param string $dest
+   *   Destination of files being copied.
+   *
+   * @return bool
+   *   TRUE if recursive copy was successful, FALSE otherwise.
+   */
+  private static function rcopy($src, $dest): bool {
+    echo "rcopy: Copying $src to $dest\n";
+
+    // If source is not a directory stop processing.
+    if (!is_dir($src)) {
+      echo "Source is not a directory";
+      return FALSE;
+    }
+
+    // If the destination directory does not exist create it.
+    if (!is_dir($dest)) {
+      if (!mkdir($dest, 0777, TRUE)) {
+        // If the destination directory could not be created stop processing.
+        echo "Can't create destination path: {$dest}\n";
+        return FALSE;
+      }
+    }
+
+    // Open the source directory to read in files.
+    $i = new \DirectoryIterator($src);
+    foreach ($i as $f) {
+      if ($f->isFile()) {
+        copy($f->getRealPath(), "$dest/" . $f->getFilename());
+      }
+      elseif (!$f->isDot() && $f->isDir()) {
+        self::rcopy($f->getRealPath(), "$dest/$f");
+        // unlink($f->getRealPath());
+      }
+    }
+
+    return TRUE;
+    // We could Remove original directories but don't do it
+    // unlink($src);
+  }
+
+  /**
+   * Copy a file from one location to another.
+   *
+   * Code is borrowed from koodimonni/composer-dropin-installer.
+   *
+   * @param string $src
+   *   File being copied.
+   * @param string $dest
+   *   Destination directory.
+   *
+   * @return bool
+   *   TRUE if copy was successful, FALSE otherwise.
+   */
+  private static function copy(string $src, string $dest): bool {
+    // If the destination directory does not exist create it.
+    if (!is_dir($dest)) {
+      if (!mkdir($dest, 0777, TRUE)) {
+        // If the destination directory could not be created stop processing.
+        echo "Can't create destination path: {$dest}\n";
+        return FALSE;
+      }
+    }
+    copy($src, "$dest/" . basename($src));
+
+    return TRUE;
+  }
+
+}

--- a/src/InstallHelperPlugin.php
+++ b/src/InstallHelperPlugin.php
@@ -176,7 +176,12 @@ class InstallHelperPlugin implements PluginInterface, EventSubscriberInterface {
     $i = new \DirectoryIterator($src);
     foreach ($i as $f) {
       if ($f->isFile()) {
+        umask(0);
         copy($f->getRealPath(), "$dest/" . $f->getFilename());
+        // Add execute permission to script file.
+        if (pathinfo($f->getFilename(), PATHINFO_EXTENSION) === 'sh') {
+          chmod("$dest/" . $f->getFilename(), 0755);
+        }
       }
       elseif (!$f->isDot() && $f->isDir()) {
         self::rcopy($f->getRealPath(), "$dest/$f");


### PR DESCRIPTION
## Description

Currently in https://github.com/wunderio/drupal-project/blob/main/.lando.yml and this project our Lando yml file contains lot of services. Some are also commented out in case you need them. In one of our projects, we don't need **Node** so how to make that optional? There should be an easy way to pick what you need and what not.

This feature adds a custom extension system and adds the first **node** extension. It's solved by using the [yq](https://github.com/mikefarah/yq) linux tool to merge 2 yml files together. 

The system does not yet have functionality to also add custom scripts, but that can be added later.

This PR also removes requirement for [koodimonni/composer-dropin-installer](https://github.com/Koodimonni/Composer-Dropin-Installer) as I realized how the dropin plugin was created and actually borrowed some code from it.

In addition to that we'll be changing the general install logic of requiring to add both the .lando.base.yml and .lando/core to each project's own repo. This way:

1. We see what changes are coming in when requiring new version of wunderio/lando-drupal
2. On fresh install of project, lando start would work. There are no hooks to fetch all of the code before .lando.yml file is red in. Everything has to be there already after cloning.

## Todo?

2. How to uninstall?
Add `unload-wunderio-lando-drupal-extensions`?

## Testing

This test is based on the guess that you don't yet have **wunderio/lando-drupal** installed.

1. Remove node service and npm tooling from your .lando.yml

4. Install current PR's  **wunderio/lando-drupal** composer package:

`lando composer require wunderio/lando-drupal:dev-feature/20-add-extensions --dev`

5. Rebuild lando:

`lando rebuild`

You are now using **wunderio/lando-drupal** package minus the Node service.

7. Load the node extension into .lando.yml and .lando.base.yml with the new tooling command:

`lando load-wunderio-lando-drupal-extensions node`

It will first write this into your local .lando.yml:

```
wunderio:
  extensions:
    - node
```

Then it'll merge the node changes into .lando.base.yml. Check that you can see the Node service and npm tooling in .lando.base.yml. Basically this https://github.com/wunderio/lando-drupal/pull/21/files#diff-2295bf9cd69f06ec8e2b148811e61665089a0a1354de813024b9d02de01e2f29 was merged into the .lando.base.yml

8. Rebuild Lando:

```
   lando rebuild
```

You should have Node service available together with `lando npm` tooling.