### PR TITLE
#24 Fix _run-scripts.sh - pass in parameters.

### DIFF
--- a/.lando/core/_run-scripts.sh
+++ b/.lando/core/_run-scripts.sh
@@ -8,19 +8,22 @@ set -exu
 export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/app/vendor/bin
 
 script_name="$1"
+# Remove the first argument (the script name) to get the remaining arguments
+shift 1
 
-# Check if a custom script exists in .lando/custom
 custom_script="/app/.lando/custom/$script_name"
 core_script="/app/.lando/core/$script_name"
 
 # Check if the custom script exists and is executable
 if [ -x "$custom_script" ]; then
     echo "Running custom script: $custom_script"
-    "$custom_script"
+    # Run the script and pass all remaining arguments.
+    "$custom_script" "$@"
 elif [ -x "$core_script" ]; then
     # If the custom script doesn't exist, run the core script.
     echo "Running core script: $core_script"
-    "$core_script"
+    # Run the script and pass all remaining arguments.
+    "$core_script" "$@"
 else
     echo "Script not found or not executable: $script_name"
     exit 1


### PR DESCRIPTION
# Description

Our wrapper script was not passing in any parameters:

We might have executed this:

`lando xdebug debug`

but what will actually executed is

`lando xdebug`

# Testing

Test that this works:

lando xdebug debug