### PR TITLE
#20 Add elasticsearch and kibana extension.

### DIFF
--- a/.lando.base.yml
+++ b/.lando.base.yml
@@ -85,33 +85,6 @@ services:
   # @see: https://docs.lando.dev/guides/external-access.html
   # database:
   #   portforward: 34567
-  # elasticsearch:
-  #   type: compose
-  #   services:
-  #     image: "docker.elastic.co/elasticsearch/elasticsearch:7.17.0"
-  #     command: "/bin/tini -- /usr/local/bin/docker-entrypoint.sh eswrapper"
-  #     user: elasticsearch
-  #     environment:
-  #       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
-  #       discovery.type: "single-node"
-  #       bootstrap.memory_lock: "true"
-  #       # Allow CORS requests.
-  #       http.cors.enabled: "true"
-  #       http.cors.allow-origin: "*"
-  #     ulimits:
-  #       memlock:
-  #         soft: "-1"
-  #         hard: "-1"
-  #     ports:
-  #       - "9200:9200"
-  #     volumes:
-  #       - esdata:/usr/share/elasticsearch/data
-  #   # Install ES plugins.
-  #   build_as_root:
-  #     - elasticsearch-plugin install analysis-icu analysis-ukrainian
-  #   volumes:
-  #     esdata:
-  #       driver: local
   # kibana:
   #   type: compose
   #   services:
@@ -141,8 +114,6 @@ proxy:
     - adminer.drupal-project.lndo.site
   mailhog:
     - mail.lndo.site
-  # elasticsearch:
-  #   - elasticsearch.lndo.site:9200
   # kibana:
   #   - kibana.lndo.site:5601
   # varnish:

--- a/.lando.base.yml
+++ b/.lando.base.yml
@@ -85,14 +85,6 @@ services:
   # @see: https://docs.lando.dev/guides/external-access.html
   # database:
   #   portforward: 34567
-  # kibana:
-  #   type: compose
-  #   services:
-  #     image: "docker.elastic.co/kibana/kibana:7.17.0"
-  #     command: "/bin/tini -- /usr/local/bin/kibana-docker"
-  #     user: kibana
-  #     ports:
-  #       - "5601:5601"
   mailhog:
     type: mailhog
     hogfrom:
@@ -114,8 +106,6 @@ proxy:
     - adminer.drupal-project.lndo.site
   mailhog:
     - mail.lndo.site
-  # kibana:
-  #   - kibana.lndo.site:5601
   # varnish:
   #   - varnish.drupal-project.lndo.site
 

--- a/extensions/elasticsearch/.lando.yml
+++ b/extensions/elasticsearch/.lando.yml
@@ -1,0 +1,32 @@
+services:
+  elasticsearch:
+    type: compose
+    services:
+      image: "docker.elastic.co/elasticsearch/elasticsearch:7.17.0"
+      command: "/bin/tini -- /usr/local/bin/docker-entrypoint.sh eswrapper"
+      user: elasticsearch
+      environment:
+        ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+        discovery.type: "single-node"
+        bootstrap.memory_lock: "true"
+        # Allow CORS requests.
+        http.cors.enabled: "true"
+        http.cors.allow-origin: "*"
+      ulimits:
+        memlock:
+          soft: "-1"
+          hard: "-1"
+      ports:
+        - "9200:9200"
+      volumes:
+        - esdata:/usr/share/elasticsearch/data
+    # Install ES plugins.
+    build_as_root:
+      - elasticsearch-plugin install analysis-icu analysis-ukrainian
+    volumes:
+      esdata:
+        driver: local
+
+proxy:
+  elasticsearch:
+    - elasticsearch.lndo.site:9200

--- a/extensions/elasticsearch/README.md
+++ b/extensions/elasticsearch/README.md
@@ -1,0 +1,43 @@
+# Elasticsearch extension
+
+This extension adds Elasticsearch 7.17.0 to the Lando configuration.
+
+## Installation
+
+1. Add Elasticsearch extension to your .lando.yml file:
+
+   ```
+   lando load-wunderio-lando-drupal-extensions elasticsearch
+   ```
+
+   This will write the following to your .lando.yml file:
+
+   ```
+   wunderio:
+     extensions:
+       - elasticsearch
+   ```
+
+   You might want to adjust the position of the new entry in .lando.yml file. For example, if you have
+   **version** parameters last, then you might want to move the wunderio entry before that. It's just
+   a matter of preference.
+
+2. Rebuild Lando:
+
+   ```
+   lando rebuild
+   ```
+
+3. Add the changes to GIT.
+
+   ```
+   git add .lando.base.yml .lando.yml
+   ```
+
+## Overview
+
+**Configuration Overview:**
+
+**Services:**
+
+- **elasticsearch:** Configuration for Elasticsearch 7.17.0.

--- a/extensions/elasticsearch/README.md
+++ b/extensions/elasticsearch/README.md
@@ -1,6 +1,7 @@
 # Elasticsearch extension
 
-This extension adds Elasticsearch 7.17.0 to the Lando configuration.
+This extension adds latest supported Elasticsearch 8.11.0 to the Lando configuration. This
+is a rolling release so if 8.11.x or 8.x gets EOL, then this will be updated to next version.
 
 ## Installation
 
@@ -40,4 +41,4 @@ This extension adds Elasticsearch 7.17.0 to the Lando configuration.
 
 **Services:**
 
-- **elasticsearch:** Configuration for Elasticsearch 7.17.0.
+- **elasticsearch:** Configuration for Elasticsearch 8.11.0.

--- a/extensions/elasticsearch_7/.lando.yml
+++ b/extensions/elasticsearch_7/.lando.yml
@@ -2,7 +2,7 @@ services:
   elasticsearch:
     type: compose
     services:
-      image: "docker.elastic.co/elasticsearch/elasticsearch:8.11.0"
+      image: "docker.elastic.co/elasticsearch/elasticsearch:7.17.0"
       command: "/bin/tini -- /usr/local/bin/docker-entrypoint.sh eswrapper"
       user: elasticsearch
       environment:

--- a/extensions/elasticsearch_7/README.md
+++ b/extensions/elasticsearch_7/README.md
@@ -1,14 +1,13 @@
-# Kibana extension
+# Elasticsearch extension
 
-This extension adds latest supported Kibana 8.11.0 to the Lando configuration. This
-is a rolling release so if 8.11.x or 8.x gets EOL, then this will be updated to next version.
+This extension adds Elasticsearch 7.17.0 to the Lando configuration.
 
 ## Installation
 
-1. Add Kibana extension to your .lando.yml file:
+1. Add Elasticsearch extension to your .lando.yml file:
 
    ```
-   lando load-wunderio-lando-drupal-extensions kibana
+   lando load-wunderio-lando-drupal-extensions elasticsearch
    ```
 
    This will write the following to your .lando.yml file:
@@ -16,7 +15,7 @@ is a rolling release so if 8.11.x or 8.x gets EOL, then this will be updated to 
    ```
    wunderio:
      extensions:
-       - kibana
+       - elasticsearch
    ```
 
    You might want to adjust the position of the new entry in .lando.yml file. For example, if you have
@@ -41,4 +40,4 @@ is a rolling release so if 8.11.x or 8.x gets EOL, then this will be updated to 
 
 **Services:**
 
-- **kibana:** Configuration for Kibana 8.11.0.
+- **elasticsearch:** Configuration for Elasticsearch 7.17.0.

--- a/extensions/kibana/.lando.yml
+++ b/extensions/kibana/.lando.yml
@@ -1,0 +1,13 @@
+services:
+  kibana:
+    type: compose
+    services:
+      image: "docker.elastic.co/kibana/kibana:7.17.0"
+      command: "/bin/tini -- /usr/local/bin/kibana-docker"
+      user: kibana
+      ports:
+        - "5601:5601"
+
+proxy:
+  kibana:
+    - kibana.lndo.site:5601

--- a/extensions/kibana/README.md
+++ b/extensions/kibana/README.md
@@ -1,0 +1,43 @@
+# Kibana extension
+
+This extension adds Kibana 7.17.0 to the Lando configuration.
+
+## Installation
+
+1. Add Kibana extension to your .lando.yml file:
+
+   ```
+   lando load-wunderio-lando-drupal-extensions kibana
+   ```
+
+   This will write the following to your .lando.yml file:
+
+   ```
+   wunderio:
+     extensions:
+       - kibana
+   ```
+
+   You might want to adjust the position of the new entry in .lando.yml file. For example, if you have
+   **version** parameters last, then you might want to move the wunderio entry before that. It's just
+   a matter of preference.
+
+2. Rebuild Lando:
+
+   ```
+   lando rebuild
+   ```
+
+3. Add the changes to GIT.
+
+   ```
+   git add .lando.base.yml .lando.yml
+   ```
+
+## Overview
+
+**Configuration Overview:**
+
+**Services:**
+
+- **kibana:** Configuration for Kibana 7.17.0.

--- a/extensions/kibana_7/.lando.yml
+++ b/extensions/kibana_7/.lando.yml
@@ -2,7 +2,7 @@ services:
   kibana:
     type: compose
     services:
-      image: "docker.elastic.co/kibana/kibana:8.11.0"
+      image: "docker.elastic.co/kibana/kibana:7.17.0"
       command: "/bin/tini -- /usr/local/bin/kibana-docker"
       user: kibana
       ports:

--- a/extensions/kibana_7/README.md
+++ b/extensions/kibana_7/README.md
@@ -1,7 +1,6 @@
 # Kibana extension
 
-This extension adds latest supported Kibana 8.11.0 to the Lando configuration. This
-is a rolling release so if 8.11.x or 8.x gets EOL, then this will be updated to next version.
+This extension adds Kibana 7.17.0 to the Lando configuration.
 
 ## Installation
 
@@ -41,4 +40,4 @@ is a rolling release so if 8.11.x or 8.x gets EOL, then this will be updated to 
 
 **Services:**
 
-- **kibana:** Configuration for Kibana 8.11.0.
+- **kibana:** Configuration for Kibana 7.17.0.

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -83,8 +83,14 @@ install_enabled_extensions() {
   # extensions, then we've also implemented removal of extensions at
   # the same time.
   LANDO_DRUPAL_PACKAGE_VERSION=$(composer show | grep -oP 'wunderio/lando-drupal\s+\K\S+')
-  BASE_YML_URL="https://raw.githubusercontent.com/wunderio/lando-drupal/${LANDO_DRUPAL_PACKAGE_VERSION}/.lando.base.yml"
-  wget -q -O .lando.base.yml $BASE_YML_URL
+
+  # Check if the version is a valid version number
+  if [[ "$LANDO_DRUPAL_PACKAGE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    BASE_YML_URL="https://raw.githubusercontent.com/wunderio/lando-drupal/${LANDO_DRUPAL_PACKAGE_VERSION}/.lando.base.yml"
+    wget -q -O .lando.base.yml "$BASE_YML_URL"
+  else
+    log_message "Invalid version: $LANDO_DRUPAL_PACKAGE_VERSION. Skipping download of .lando.base.yml."
+  fi
 
   # Check if the extensions array is empty.
   if [ ${#extensions[@]} -eq 0 ]; then

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -77,19 +77,18 @@ install_enabled_extensions() {
   # Use yq to extract the extension values from .lando.yml and store them in an array.
   extensions=($(yq eval '.wunderio.extensions[]' .lando.yml))
 
-  # Always fetch the clean .lando.base.yml from Github before doing
-  # any changes to it. We might not even have vendor folder available
-  # to reset it from there. If we always start from fresh and re-add
-  # extensions, then we've also implemented removal of extensions at
-  # the same time.
-  LANDO_DRUPAL_PACKAGE_VERSION=$(composer show | grep -oP 'wunderio/lando-drupal\s+\K\S+')
-
-  # Check if the version is a valid version number
-  if [[ "$LANDO_DRUPAL_PACKAGE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    BASE_YML_URL="https://raw.githubusercontent.com/wunderio/lando-drupal/${LANDO_DRUPAL_PACKAGE_VERSION}/.lando.base.yml"
-    wget -q -O .lando.base.yml "$BASE_YML_URL"
+  # Reset the .lando.base.yml file to the original state before merging extensions.
+  if [ -f "vendor/wunderio/lando-drupal/.lando.base.yml" ]; then
+    cp vendor/wunderio/lando-drupal/.lando.base.yml .lando.base.yml
   else
-    log_message "Invalid version: $LANDO_DRUPAL_PACKAGE_VERSION. Skipping download of .lando.base.yml."
+    # If the local file doesn't exist, download from GitHub
+    LANDO_DRUPAL_PACKAGE_VERSION=$(composer show | grep -oP 'wunderio/lando-drupal\s+\K\S+')
+
+    # Check if the version is a valid version number
+    if [[ "$LANDO_DRUPAL_PACKAGE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      BASE_YML_URL="https://raw.githubusercontent.com/wunderio/lando-drupal/${LANDO_DRUPAL_PACKAGE_VERSION}/.lando.base.yml"
+      wget -q -O .lando.base.yml "$BASE_YML_URL"
+    fi
   fi
 
   # Check if the extensions array is empty.


### PR DESCRIPTION
Add Elasticsearch and Kibana extension.

## Testing

1. Require this branch:

`lando composer require wunderio/lando-drupal:dev-feature/20-add-elasticsearch-extension  --dev`

2. Remove any elasticsearch and kibana entries from your .lando.yml.

3. Install **Elasticsearch** extension

`lando load-wunderio-lando-drupal-extensions elasticsearch`

4. Install **Kibana** extension

`lando load-wunderio-lando-drupal-extensions kibana`

5. Rebuild lando

`lando rebuild`

6. To remove extensions (this was added in https://github.com/wunderio/lando-drupal/pull/28 )

`lando unload-wunderio-lando-drupal-extensions elasticsearch`
`lando unload-wunderio-lando-drupal-extensions kibana`

or

`lando unload-wunderio-lando-drupal-extensions elasticsearch,kibana`