### PR TITLE
#22 Add Drush @local alias.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ minimally the *name* parameter.
 4. Add changes to GIT:
    ```
    git add .lando/custom/ &&
+   git add drush/sites/ &&
    git add -p .gitignore composer.json composer.lock
    ```
 

--- a/drush/sites/local.site.yml
+++ b/drush/sites/local.site.yml
@@ -1,0 +1,5 @@
+# Add local alias.
+# Docs at https://github.com/drush-ops/drush/blob/master/examples/example.site.yml
+local:
+  root: ${env.LANDO_WEBROOT}
+  uri: ${env.DRUSH_OPTIONS_URI}

--- a/src/InstallHelperPlugin.php
+++ b/src/InstallHelperPlugin.php
@@ -148,8 +148,9 @@ class InstallHelperPlugin implements PluginInterface, EventSubscriberInterface {
     self::copy($src_base, $this->projectDir);
 
     // Copy over the Drush aliases file.
-    $src_base = "{$this->vendorDir}/" . self::PACKAGE_NAME . '/drush/sites/local.site.yml';
-    self::copy($src_base, "$this->projectDir}/drush/sites");
+    $src_drush_aliases = "{$this->vendorDir}/" . self::PACKAGE_NAME . '/drush/sites';
+    $dest_drush_aliases = "{$this->projectDir}/drush/sites";
+    self::rcopy($src_drush_aliases, $dest_drush_aliases);
   }
 
   /**

--- a/src/InstallHelperPlugin.php
+++ b/src/InstallHelperPlugin.php
@@ -146,6 +146,10 @@ class InstallHelperPlugin implements PluginInterface, EventSubscriberInterface {
     // Copy over the .lando.base.yml file.
     $src_base = "{$this->vendorDir}/" . self::PACKAGE_NAME . '/.lando.base.yml';
     self::copy($src_base, $this->projectDir);
+
+    // Copy over the Drush aliases file.
+    $src_base = "{$this->vendorDir}/" . self::PACKAGE_NAME . '/drush/sites/local.site.yml';
+    self::copy($src_base, "$this->projectDir}/drush/sites");
   }
 
   /**


### PR DESCRIPTION
Add Drush @local alias. We use this during Lando setup:

https://github.com/wunderio/lando-drupal/blob/main/.lando.base.yml#L153

Also some developers might be used to it.

# Testing

1. Require this branch with Composer

`lando composer require wunderio/lando-drupal:dev-feature/22-fix-local-alias  --dev`

2. Check that the drush/sites/local.site.yml was added to your local site.

3. Test that @local works

 ` lando drush @local uli`
