### PR TITLE
Feature/35 add documentation about build steps

### DIFF
--- a/.lando.base.yml
+++ b/.lando.base.yml
@@ -56,12 +56,15 @@ services:
     run_as_root:
       - "/app/.lando/core/_run-scripts.sh services-adminer-run-as-root.sh"
   appserver:
+    build_as_root:
+      - "/app/.lando/core/_run-scripts.sh services-appserver-build-as-root.sh"
     # Install dependencies when building lando.
     build:
       - "/app/.lando/core/_run-scripts.sh services-appserver-build.sh"
     run_as_root:
-      - ln -snf /usr/share/zoneinfo/Europe/Helsinki /etc/localtime
-      - echo "Europe/Helsinki" > /etc/timezone
+      - "/app/.lando/core/_run-scripts.sh services-appserver-run-as-root.sh"
+    run:
+      - "/app/.lando/core/_run-scripts.sh services-appserver-run.sh"
     # Uncomment this if you need to edit files inside the container
     #build_as_root:
     #  - apt update -y

--- a/.lando/core/services-appserver-build-as-root.sh
+++ b/.lando/core/services-appserver-build-as-root.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+#
+# Helper script to run appserver build_as_root commands.
+#
+
+set -exu
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/app/vendor/bin

--- a/.lando/core/services-appserver-run-as-root.sh
+++ b/.lando/core/services-appserver-run-as-root.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+#
+# Helper script to run appserver run_as_root commands.
+#
+
+set -exu
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/app/vendor/bin
+
+ln -snf /usr/share/zoneinfo/Europe/Helsinki /etc/localtime
+echo "Europe/Helsinki" > /etc/timezone

--- a/.lando/core/services-appserver-run.sh
+++ b/.lando/core/services-appserver-run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+#
+# Helper script to run appserver run commands.
+#
+
+set -exu
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/app/vendor/bin

--- a/README.md
+++ b/README.md
@@ -43,6 +43,34 @@ minimally the *name* and *recipe* parameter.
 
    All available extensions are listed at https://github.com/wunderio/lando-drupal/tree/main/extensions
 
+6. We need to migrate build steps due to the inability to overwrite them from .lando.yml. For instance, in
+   the current setup in .lando.base.yml file we have this:
+
+   ```
+   services:
+     appserver:
+       build:
+         - "/app/.lando/core/_run-scripts.sh services-appserver-build.sh"
+   ```
+
+   The above executes services-appserver-build.sh script from .lando/core/ folder, and it runs *composer install*.
+
+   If now in your .lando.yml you have also *composer install* in the same build step, then this is also executed.
+   Basically Lando stacks the commands in build steps.
+
+   ```
+   services:
+     appserver:
+      build:
+        - "composer install"
+   ```
+
+   To resolve this issue, the recommended approach is to remove the build step from .lando.yml. Instead, copy the
+   .lando/core/services-appserver-build.sh file to your .lando/custom/ folder.
+   Then, customize it to suit your preferences. The line in .lando.base.yml -
+   '/app/.lando/core/_run-scripts.sh services-appserver-build.sh' - will first check for the presence of
+   services-appserver-build.sh in the .lando/custom/ folder. If it's not found, it will execute it from .lando/core/."
+
 ## Overview
 
 **Configuration Overview:**


### PR DESCRIPTION
Adding all of the build steps for appserver for easy way to overwrite them.

Also add readme step on how to migrate build steps.