### PR TITLE
#85 Fix lando rebuild error when wunderio/lando-drupal is not install…

### DIFF
--- a/.lando.base.yml
+++ b/.lando.base.yml
@@ -116,7 +116,7 @@ events:
   post-db-import:
     - appserver: "cd $LANDO_WEBROOT && drush cache:rebuild -y && drush @local user:login"
   pre-rebuild:
-    - appserver: "/app/vendor/wunderio/lando-drupal/scripts/load_extensions.sh"
+    - appserver: "SCRIPT=/app/vendor/wunderio/lando-drupal/scripts/load_extensions.sh && [ -f \"$SCRIPT\" ] && bash \"$SCRIPT\""
 
 env_file:
   - .lando/core/.env


### PR DESCRIPTION
## Description

When reviewing https://github.com/wunderio/client-fi-hy-natlib/pull/554/files#diff-307b4548b91e997f23c35d90ed5e9a044e156b90425c9923d6b85d7dc11e67e2 I came across a small bug.

I didn't yet have the package installed in vendor and I checked out the new branch. I ran lando rebuild and saw error that /app/vendor/wunderio/lando-drupal/scripts/load_extensions.sh does not exist. We have this set in pre-rebuild events and makes sense that it's not there yet. But the script doesn't do anything that we need at this point. All of the extensions are already installed in .lando.base.yml and under .lando/. It's just an extra step to make sure everything is loaded or in case you updated .lando.base.yml. So I think it's ok that some times it's not there there, but Lando should not be getting error code because of it.

## Testing

You can see the error when testing https://github.com/wunderio/client-fi-hy-natlib/pull/554 
1. `git checkout master`
2. `lando rebuild -y`
3. `git checkout drupal_live_template_implementation`
4. `lando rebuild -y`
Now you see the error:

![image](https://github.com/wunderio/lando-drupal/assets/492375/263339ef-d672-4e74-b3bf-255cfcfd434d)
